### PR TITLE
Dev alternate compare methods

### DIFF
--- a/chronos/hit_calling.py
+++ b/chronos/hit_calling.py
@@ -443,7 +443,7 @@ isntances or one of %r" % list(self.comparison_effect_dict.keys())
 		self.distinguished_map, self.distinguished_result, \
 			distinguished_gene_effect = self.get_distinguished_results(
 			self.nondistinguished_map, condition_pair, comparison_effect, 
-			readcount_gene_totals, **kwargs
+			self.readcount_gene_totals, **kwargs
 		)
 
 		print("training model with permuted conditions")

--- a/chronos/model.py
+++ b/chronos/model.py
@@ -389,14 +389,13 @@ batches, too few to estimate overdispersion.")
 
 	return alpha
 
-def nan_outgrowths(readcounts, sequence_map, guide_gene_map, absolute_cutoff=2, gap_cutoff=2):
+def nan_outgrowths(readcounts, sequence_map, guide_gene_map, absolute_cutoff=2, gap_cutoff=2,
+				  rpm_normalize=False):
 	'''
 	NaNs readcounts in cases where all of the following are true:
-		- The value  for the guide/replicate pair corresponds to the most positive log fold change of all guides and all replicates 
-			for a cell line
 		- The logfold change for the guide/replicate pair is greater than `absolute_cutoff`
 		- The difference between the lfc for this pair and the next most positive pair for that gene and cell line is greater than 
-			gap_cutoff
+			gap_cutoff. 
 	Readcounts are mutated in place.
 	Parameters:
 		readcounts (`pandas.DataFrame`): readcount matrix with replicates on rows, guides on columns
@@ -404,58 +403,60 @@ def nan_outgrowths(readcounts, sequence_map, guide_gene_map, absolute_cutoff=2, 
 		guide_gene_map (`pandas.DataFrame`): has string columns "sequence_ID", "cell_line_name", and "pDNA_batch"
 
 	'''
+	
 	check_inputs(readcounts={'default': readcounts}, sequence_map={'default': sequence_map},
 					 guide_gene_map={'default': guide_gene_map})
+	
 	print('calculating LFC')
-	fc = calculate_fold_change(readcounts, sequence_map)
+	fc = calculate_fold_change(readcounts, sequence_map, rpm_normalize)
 	lfc = pd.DataFrame(
 		np.log2(fc.values), index=fc.index,columns=fc.columns
 	)
 
+	print("stacking and annotating LFC")
+	lfc_stack = lfc.copy()
+	lfc_stack.index.name = "sequence_ID"
+	lfc_stack.columns.name = "sgrna"
+	
+	lfc_stack = lfc_stack\
+		.stack()\
+		.reset_index()\
+		.merge(sequence_map[["sequence_ID", "cell_line_name"]], how="left", on="sequence_ID")\
+		.merge(guide_gene_map[["sgrna", "gene"]], how="left", on="sgrna")\
+		.rename(columns={0: "LFC"})\
+		.sort_values("LFC")
 
-	print('finding maximum LFC calls')
-	ggtemp = guide_gene_map.set_index('sgrna').gene.sort_values()
-	multigenes = set(ggtemp.value_counts().loc[lambda x: x > 1].index)
-	ggtemp = ggtemp[ggtemp.isin(multigenes)]
+	groups = lfc_stack.groupby(["cell_line_name", "gene"])
 
-	max_lfc = lfc.groupby(ggtemp, axis=1).max()
-	print("filtering")
-	potential_cols = max_lfc.columns[(max_lfc.max() > absolute_cutoff).values]
-	potential_rows = max_lfc.index[(max_lfc.max(axis=1) > absolute_cutoff).values]
-	max_lfc = max_lfc.loc[potential_rows, potential_cols]
-	ggtemp = ggtemp[ggtemp.isin(potential_cols)]
-	lfc_filtered = lfc.loc[potential_rows, ggtemp.index]
-	ggreversed = pd.Series(ggtemp.index.values, index=ggtemp.values).sort_index()
+	groups = {key: val for key, val in groups}
 
-	print("finding second highest LFC calls")
-	second_highest_indices = np.cumsum(ggtemp.value_counts().sort_index())-2
+	print("subsetting to cell line/gene pairs with at least two LFC measurements \
+and one LFC > `absolute_cutoff`")
+	# note this is written to avoid conditionals in the loop
+	max_lfc = pd.Series({key: val.LFC.max() for key, val in groups.items()})
+	len_vals = pd.Series({key: val.LFC.notnull().sum() for key, val in groups.items()})
+	consider = max_lfc.index[(max_lfc > absolute_cutoff) & (len_vals>1)]
 
-	def second_highest(x):
-		return x.values[np.argpartition(-x.values, 1)[1]]
+	print("finding gaps that exceed `gap_cutoff`")
+	is_bad = pd.Series({key: groups[key].LFC.values[-1] - groups[key].LFC.values[-2] > gap_cutoff
+					for key in consider})
+	bad_groups = is_bad.index[is_bad.values]
+	
+	print("found %i outgrowths, %1.1E of the total" % (len(bad_groups), len(bad_groups)/lfc.notnull().sum().sum()))
+	if not len(bad_groups):
+		return
 
-	max_row_2nd_column = lfc_filtered.T.groupby(ggtemp, axis=0).agg(second_highest).T 
+	print("NaNing")
+	bad_indices = list(zip(*[(groups[key].sequence_ID.values[-1], groups[key].sgrna.values[-1])
+					for key in bad_groups]))
 
-	second_highest = max_row_2nd_column.loc[max_lfc.index, max_lfc.columns].values 
+	mask = pd.DataFrame({
+		"sequence_ID": list(bad_indices[0]), "sgrna": list(bad_indices[1]), "value": True
+	})
 
-	gap = pd.DataFrame(max_lfc.values - second_highest, #second_highest
-		index=max_lfc.index, columns=max_lfc.columns)
-
-	print('finding sequences and guides with outgrowth')
-
-	masked = max_lfc.copy()
-	masked[(max_lfc <= absolute_cutoff) | (gap <= gap_cutoff)] = np.nan
-	masked = masked.reindex(index=lfc_filtered.index, columns=ggtemp.values).fillna(False)
-	masked.columns = ggtemp.index
-	max_lfc_expanded = max_lfc.reindex(index=lfc_filtered.index, columns=ggtemp.values)
-	max_lfc_expanded.columns = ggtemp.index
-	mask = (lfc_filtered == max_lfc_expanded) & masked
-	mask = mask.reindex(index=readcounts.index, columns=readcounts.columns).fillna(False).astype(bool)
-
-	print("NAing %i readcounts (%1.5f of total)" % (
-		mask.sum().sum(), mask.sum().sum()/readcounts.notnull().sum().sum()
-		)
-	)
-
+	mask = pd.pivot(mask, index="sequence_ID", columns="sgrna", values="value")
+	mask = mask.reindex(index=readcounts.index, columns=readcounts.columns).fillna(False)
+	
 	readcounts.mask(mask, inplace=True)
 
 
@@ -702,29 +703,29 @@ class Chronos(object):
 			nodes are exposed as properties which return properly indexed Pandas objects. 
 			
 		Properties (type `help(Chronos.<property>) to learn more):
-		    cell_efficacy
-		    cost
-		    cost_presum
-		    days
-		    estimated_fold_change
-		    full_cost
-		    gene_effect
-		    guide_efficacy
-		    growth_rate
-		    efficacy
-		    excess_variance
-		    learning_rate
-		    library_means
-		    library_effect
-		    mask
-		    measured_t0
-		    normalized_readcounts
-		    predicted_readcounts_scaled
-		    predicted_readcounts
-		    screen_delay
-		    t0
-		    t0_core
-		    t0_offset
+			cell_efficacy
+			cost
+			cost_presum
+			days
+			estimated_fold_change
+			full_cost
+			gene_effect
+			guide_efficacy
+			growth_rate
+			efficacy
+			excess_variance
+			learning_rate
+			library_means
+			library_effect
+			mask
+			measured_t0
+			normalized_readcounts
+			predicted_readcounts_scaled
+			predicted_readcounts
+			screen_delay
+			t0
+			t0_core
+			t0_offset
 		'''
 
 
@@ -844,7 +845,7 @@ class Chronos(object):
 
 		self._pretrained = pretrained
 		self._is_model_loaded = False
-        
+		
 
 		##################    C  R  E  A  T  E       V  A  R  I  A  B  L  E  S   #######################
 
@@ -1258,7 +1259,7 @@ class Chronos(object):
 		with tf.compat.v1.name_scope("days"):
 			_days = {key: 
 				tf.constant(
-					  	  Chronos.default_timepoint_scale 
+						  Chronos.default_timepoint_scale 
 						* val.set_index('sequence_ID').loc[self.index_map[key]].days.astype(self.np_dtype).values, 
 					dtype=dtype, 
 					shape=(len(self.index_map[key]), 1), 
@@ -1385,7 +1386,7 @@ class Chronos(object):
 						tf.transpose(a=_t0_offset[key])
 						# for every guide, subtract the mean offset for all guides targetiing the same gene
 					  - tf.gather(
-					  		_combined_t0_offset, 
+							_combined_t0_offset, 
 							self.guide_map[key]['gather_ind_inner'], 
 							axis=1
 						)
@@ -1469,7 +1470,7 @@ class Chronos(object):
 		with tf.compat.v1.name_scope("screen_delay"):
 			v_screen_delay = tf.Variable(
 							np.sqrt(Chronos.default_timepoint_scale * initial_screen_delay) * np.ones((1, self.ngenes), dtype=self.np_dtype),
-					 		dtype=dtype, name="base")
+							dtype=dtype, name="base")
 			_screen_delay = tf.square(v_screen_delay)
 		tf.compat.v1.summary.histogram("screen_delay", _screen_delay)
 		print("built screen delay")
@@ -1497,7 +1498,7 @@ class Chronos(object):
 						(tf.reduce_mean(input_tensor=_residue, axis=0, name="sum_over_guides"))[tf.newaxis, :],
 						name="mean_centered"
 						)
-                  
+				  
 			_combined_gene_effect = tf.add(v_mean_effect, _true_residue, name="GE")
 
 			with tf.compat.v1.name_scope("library_effect"):
@@ -1857,12 +1858,12 @@ class Chronos(object):
 		#this breaks when medians.min() == medians.quantile(q); e.g. q% of guides are at 0 median fc
 		#depleting_guides = medians.loc[lambda x: x < medians.quantile(cell_efficacy_guide_quantile)].index
 		depleting_guides = medians.loc[lambda x: x <= medians.quantile(cell_efficacy_guide_quantile)].index
-        #####
+		#####
 		# if medians.min() == medians.quantile(cell_efficacy_guide_quantile):
 		# 	depleting_guides = medians.loc[lambda x: x <= medians.quantile(cell_efficacy_guide_quantile)].index # keep
 		# else:
 		# 	depleting_guides = medians.loc[lambda x: x < medians.quantile(cell_efficacy_guide_quantile)].index   
-        #####
+		#####
 		cell_efficacy = 1 - fc[depleting_guides].median(axis=1)
 		if (cell_efficacy <=0 ).any() or (cell_efficacy > 1).any() or cell_efficacy.isnull().any():
 			raise RuntimeError("estimated efficacy outside bounds. \n%r\n%r" % (cell_efficacy.sort_values(), fc))
@@ -1941,10 +1942,10 @@ class Chronos(object):
 				print(self.sess.run(
 					(
 							self._normalized_readcounts[key]+1e-6) 
-					 	* tf.math.log(self._excess_variance_expanded[key] 
-					 	* (self._normalized_readcounts[key] + 1e-6) 
+						* tf.math.log(self._excess_variance_expanded[key] 
+						* (self._normalized_readcounts[key] + 1e-6) 
 					 ), 
-					 	self.run_dict)
+						self.run_dict)
 				)
 				raise ValueError("%i nulls found in self._cost_presum[%s]" % (pd.isnull(df).sum().sum(), key))
 			print('\t' + key + ' _cost')
@@ -1968,8 +1969,8 @@ class Chronos(object):
 		'''
 		return {
 			key: np.concatenate(self.guide_gene_map[key].groupby("gene").sgrna.apply(lambda x: 
-                                      np.random.choice(x, size=int(np.ceil(len(x)/3)), replace=False)
-                                     ).values)
+									  np.random.choice(x, size=int(np.ceil(len(x)/3)), replace=False)
+									 ).values)
 			for key in self.keys
 		}
 
@@ -2059,7 +2060,7 @@ class Chronos(object):
 		'''
 		if self._pretrained != self._is_model_loaded:
 			raise RuntimeError("Model is built to use a pretrained model, but no model was loaded. Please use model.load()")        
-        
+		
 		rates = np.exp(np.linspace(np.log(starting_learn_rate), np.log(self.max_learning_rate), burn_in_period))
 		start_time = time()
 		start_epoch = self.epoch
@@ -2111,8 +2112,8 @@ class Chronos(object):
 
 
 #########################               I  /  O              ###################################           
-                
-                
+				
+				
 	def load(self, gene_effect, guide_efficacy, t0_offset, screen_delay, cell_efficacy, 
 		library_effect):
 		'''
@@ -2121,17 +2122,17 @@ class Chronos(object):
 		if self._pretrained != True:
 			raise RuntimeError("Model is built to train without existing data. \
 To load a pretrained model, you must reinitialize Chronos with `pretrained=True`")
-        
-        # convert cell_line_efficacy output into dictionary of cell lines to sets of library names
+		
+		# convert cell_line_efficacy output into dictionary of cell lines to sets of library names
 		cells_to_libraries_screened = dict()
 		for cell_id in cell_efficacy.index:
-            # only keep the libraries that are present in the newest data (self.keys)
+			# only keep the libraries that are present in the newest data (self.keys)
 			cells_to_libraries_screened[cell_id] = set(
 				cell_efficacy\
 				.loc[cell_id, ~cell_efficacy.loc[cell_id, :].isna()]\
 				.index
 			).intersection(self.keys)
-        
+		
 		missing = set(self.keys) - set.union(*[libs for libs in cells_to_libraries_screened.values()])
 		if len(missing):
 			raise ValueError(
@@ -2139,7 +2140,7 @@ To load a pretrained model, you must reinitialize Chronos with `pretrained=True`
 that includes all the libraries in the new screen(s), run Chronos without a pretrained model, or exclude those libraries from \
 your data" % missing
 			)
-        
+		
 		mask = {}
 		for cell in self.all_cells:
 			if cell in cells_to_libraries_screened:
@@ -2160,23 +2161,23 @@ your data" % missing
 		self._gene_effect_mask = _gene_effect_mask
 		self.mask_count = mask_count
 
-        # want to use the gene_effect matrix and not v_mean_effect's mean because the training data's masking is relevant
+		# want to use the gene_effect matrix and not v_mean_effect's mean because the training data's masking is relevant
 		means = gene_effect.mean().reindex(index=self.all_genes).values.reshape(1, -1)
 		self.sess.run(self.v_mean_effect.assign(means))
-        
+		
 		self.guide_efficacy = guide_efficacy
 
 		self.t0_offset = t0_offset
-        
+		
 		self.screen_delay = screen_delay
-        
+		
 		self.library_effect = library_effect
-        
+		
 		self._is_model_loaded = True
 		print('Chronos model loaded')
 		print('ready to train')
-    
-    
+	
+	
 	def import_model(self, directory):
 		'''
 		Quickly load a subset of Chronos parameters from a directory. 
@@ -2215,8 +2216,8 @@ your data" % missing
 			screen_delay = pd.Series(3, index=gene_effect.columns)
 		library_effect = pd.read_csv(os.path.join(directory, 'library_effect.csv'), index_col=0)        
 		self.load(gene_effect, guide_efficacy, t0_offset, screen_delay, cell_line_efficacy, library_effect)
-           
-        
+		   
+		
 
 	def save(self, directory, overwrite=False, include_inputs=True, include_outputs=True):
 		'''
@@ -2450,7 +2451,7 @@ your data" % missing
 		return {key: pd.DataFrame(self.sess.run(self._cost_presum[key], self.run_dict), 
 							  index=self.index_map[key], columns=self.column_map[key])
 				for key in self.keys}
-    
+	
 
 	@property
 	def days(self):
@@ -2479,7 +2480,7 @@ your data" % missing
 		}
 		return {
 			key: pd.DataFrame(
-				  	output[key].values \
+					output[key].values \
 					/ measured_t0[key].loc[mapper[key]].values,
 				index=output[key].index, 
 				columns=output[key].columns

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require['all'] = sorted(set.union(*[set(v) for v in extras_require.values
 
 setup(
 	name='crispr_chronos',
-	version='2.2.1',
+	version='2.2.2',
 	author="BroadInstitute CDS",
 	description="Time series modeling of CRISPR perturbation readcounts in biological data",
 	packages=find_packages(),


### PR DESCRIPTION
Changed strategies for comparison. Now by default uses the change in likelihood rather than gene effect as the effect for computing empirical p-values. For each trained model, for each cell line/condition, the likelihood of the data is estimated, then estimated again using the gene effect of the same cell line in the opposite condition. The difference in the sum of the likelihoods over guides/replicates/conditions is the effect. P-values are computed with only right-tail tests. 

The nan_outgrowths function was also changed to do what it claimed to do. Now, if there is only one guide but multiple replicates for a gene, and the gap between replicates is larger than gap_cutoff, the maximum value can still be NaNed.