### PR TITLE
Change pandas query

### DIFF
--- a/chronos/evaluations.py
+++ b/chronos/evaluations.py
@@ -316,7 +316,7 @@ def all_replicate_plot(readcounts, sequence_map, cell_line, plot_width):
 	`replicate_plot` for all pairs of replicates of `cell_line`. See `chronos.Chronos` for a description
 	of `sequence_map`. `plot_width` gives the plot width in inches.
 	'''
-	reps = sequence_map.query("cell_line_name == %r" % cell_line).sequence_ID.unique()
+	reps = sequence_map.query("cell_line_name == @cell_line").sequence_ID.unique()
 	rep_labels = dict(zip(reps, trim_overlapping_lead_and_tail(reps)))
 	n = 0
 	titles = {}
@@ -346,10 +346,10 @@ def pDNA_plot(readcounts, sequence_map, rep, sgrnas=None):
 		if not controls:
 			raise ValueError("None of the specified sgRNAs are in the readcounts columns: \n%r" 
 							% sgrnas)
-	batch_label = sequence_map.query("sequence_ID == %r" % rep).iloc[0]['pDNA_batch']
+	batch_label = sequence_map.query("sequence_ID == @rep").iloc[0]['pDNA_batch']
 	pdna_seq = sequence_map\
 				.query("cell_line_name == 'pDNA'")\
-				.query("pDNA_batch == %r" % batch_label)\
+				.query("pDNA_batch == @batch_label")\
 				.sequence_ID
 	pdna = np.log2(readcounts.loc[pdna_seq]+1).median()
 	ltp = np.log2(readcounts.loc[rep]+1)
@@ -377,7 +377,7 @@ def paired_pDNA_plots(readcounts, sequence_map, cell_line,
 	but `plot_height` specifies subplot height. This will be adjusted if the total figure
 	height would exceed `page_height`. See `pDNA_plot` for other parameters.
 	'''
-	reps = sequence_map.query("cell_line_name == %r" % cell_line).sequence_ID.unique()
+	reps = sequence_map.query("cell_line_name == @cell_line").sequence_ID.unique()
 	labels = dict(zip(reps, trim_overlapping_lead_and_tail(reps)))
 	left_title = "Negative Controls"
 	right_title = "Positive Controls"
@@ -1282,7 +1282,7 @@ def guide_palette(guide_map, gene, base_rgb=None):
 		raise KeyError("`base_rgb` missing keys in the `guide_map`")
 	palette = {}
 	for i, key in enumerate(guide_map):
-		guides = guide_map[key].query("gene == %r" % gene).sgrna.unique()
+		guides = guide_map[key].query("gene == @gene").sgrna.unique()
 		h, s, v = rgb_to_hsv(*base_rgb[key])
 		if len(guides) == 0:
 			v_interval = []
@@ -1408,9 +1408,9 @@ def single_line_interrogation(data, gene, line, ax=None,
 	'''
 	if not ax is None:
 		plt.sca(ax)
-	guides = {library: data['guide_map'][library].query("gene == %r" % gene).sgrna.unique()
+	guides = {library: data['guide_map'][library].query("gene == @gene").sgrna.unique()
 				for library in data['guide_map']}
-	sequences = {library: data['sequence_map'][library].query("cell_line_name == %r" % line).sequence_ID.unique()
+	sequences = {library: data['sequence_map'][library].query("cell_line_name == @line").sequence_ID.unique()
 				for library in data['sequence_map']
 				}
 

--- a/chronos/hit_calling.py
+++ b/chronos/hit_calling.py
@@ -456,7 +456,7 @@ def _remap_growth_rates(growth_rate, old_map, new_map):
 	growth_rates = []
 	
 	for library, mapper in old_map.items():
-		sub = growth_rate.query("library == %r" % library).copy()
+		sub = growth_rate.query("library == @library").copy()
 		mapper = mapper[["sequence_ID", "replicate_ID"]].drop_duplicates(subset=["replicate_ID"])
 		sub = pd.merge(sub, mapper, on="replicate_ID", how="left")
 		sub["replicate_ID"] = new_map\

--- a/chronos/reports.py
+++ b/chronos/reports.py
@@ -269,7 +269,7 @@ def qc_initial_data(title, readcounts, sequence_map, guide_map, negative_control
 	for line in sequence_map.cell_line_name.unique():
 		if line == 'pDNA':
 			continue
-		reps = sequence_map.query("cell_line_name == %r" % line).sequence_ID
+		reps = sequence_map.query("cell_line_name == @line").sequence_ID
 		corrs = fast_cor(lfc.loc[reps].T)
 		np.fill_diagonal(corrs.values, np.nan)
 		mean_corrs.append(corrs.mean())
@@ -414,7 +414,7 @@ sgRNAs should tend to fall below the diagonal. Note that each axis is the log(no
 		story.append(PageBreak())
 		story.append(Paragraph(line, style=styles["Heading3"]))
 
-		reps = sequence_map.query("cell_line_name == %r" % cell_line).sequence_ID.unique()
+		reps = sequence_map.query("cell_line_name == @cell_line").sequence_ID.unique()
 		rep_labels = dict(zip(reps, trim_overlapping_lead_and_tail(reps)))
 		n = 0
 		titles = {}
@@ -628,8 +628,8 @@ The FDRs should be considered optimistic."
 
 		for library in library_data:
 
-			gr, cle = data["growth_rate"].query("library == %r" % library)["growth_rate"].dropna().align(
-				data['replicate_efficacy'].query("library == %r" % library)["replicate_efficacy"].dropna(), 
+			gr, cle = data["growth_rate"].query("library == @library")["growth_rate"].dropna().align(
+				data['replicate_efficacy'].query("library == @library")["replicate_efficacy"].dropna(), 
 				join="inner"
 			)
 


### PR DESCRIPTION
There was a bug with numpy 2.X for some queries in reports/evaluations. Pandas `.query("x == %r" % item)` would fail when `item` was a numpy dtype, because its representation returned `np.float64(val)` which could not be resolved by pandas. These queries have been changed to use the syntax `.query("x == @item")`